### PR TITLE
set always_2d=True

### DIFF
--- a/python/wpe.py
+++ b/python/wpe.py
@@ -154,7 +154,7 @@ class WpeMethod(object):
         return np.concatenate((xk_buf[0:self.d], dk))
 
     def load_audio(self, filename):
-        data, fs = sf.read(filename)
+        data, fs = sf.read(filename, always_2d=True)
         data = data.T
         assert(data.shape[0] >= self.channels)
         if data.shape[0] > self.channels:


### PR DESCRIPTION
see https://pysoundfile.readthedocs.io/en/0.9.0/#breaking-changes
> In 0.8.0, we changed the default value of always_2d from True to False.